### PR TITLE
Add top-right hero image with caption

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # <span style="color:purple" font-family:helvetica>Xiaolong Yang</span>
 
+<figure style="float: right; margin-left: 20px; text-align: center;">
+  <img src="xl_talk.png" alt="Neural Connection Symphony" width="300"/>
+  <figcaption style="font-size: 12px;">
+    Neural Connection Symphony: a microscopic journey through living neural networks during moments of profound human experience—learning, excitement, and love. Inspired by Neuropit #13 by the Zairja Collective; created with sora and claude ai.
+  </figcaption>
+</figure>
+
 Welcome! I am a G2 graduate student in Harvard University's Master's program of Regional Studies - East Asia. I am fortunate to be advised by Prof. [Kosuke Imai](https://imai.fas.harvard.edu/) and Prof. [Christina Davis](https://scholar.harvard.edu/cldavis/home).
 
 My CV can be found <a href="pdfs/cv_xly_web.pdf" target="_blank">here</a>.


### PR DESCRIPTION
## Summary
- Display `xl_talk.png` at the top-right of the homepage
- Add small-font caption describing the Neural Connection Symphony image

## Testing
- `npm test` *(fails: Could not read package.json)*
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a2c3e903c8332b694d8c4239a1425